### PR TITLE
ChatboxAvatar: fix crash on "read-only" message bar

### DIFF
--- a/plugins/ChatboxAvatar/src/index.tsx
+++ b/plugins/ChatboxAvatar/src/index.tsx
@@ -103,9 +103,9 @@ export const onLoad = () => {
       const insertPoint = findInReactTree(
         ret,
         (x) => x?.children?.[0]?.props?.actions
-      ).children;
+      )?.children;
 
-      insertPoint.splice(0, 0, <AvatarAction />);
+      if (insertPoint) insertPoint.splice(0, 0, <AvatarAction />);
     })
   );
 };


### PR DESCRIPTION
Though it rarely appears anymore, the "read-only" message bar still exists and has incompatible props with the injection.